### PR TITLE
Og image rake task fix #158 

### DIFF
--- a/app/services/og_image_service.rb
+++ b/app/services/og_image_service.rb
@@ -1,0 +1,38 @@
+class OgImageService
+  def initialize(project_id, page_id, page_title)
+    @project_id = project_id
+    @page_id = page_id
+    @page_title = page_title
+  end
+
+  def generate
+    img = Magick::ImageList.new("#{Rails.root}/public/images/qkspace.png")
+
+    title = Magick::Draw.new
+    title.font = "#{Rails.root}/public/assets/Lato-Regular.woff"
+    title.pointsize = 46
+    title.fill = 'white'
+    title.gravity = Magick::CenterGravity
+    title.annotate(img, 0, 0, 0, 140, wrap_text(@page_title))
+
+    FileUtils.mkdir_p(og_image_path)
+
+    img.write("#{og_image_path}/og-image.jpg")
+  end
+
+  def og_image_path
+    if Rails.env.test?
+      "#{Rails.root}/public/images/opengraph/test/#{@project_id}/#{@page_id}"
+    else
+      "#{Rails.root}/public/images/opengraph/#{@project_id}/#{@page_id}"
+    end
+  end
+
+  private
+
+  def wrap_text(text, col = 50)
+    # Regular expression to limit the number of chars per line
+    # default 50 chars each line
+    text.gsub(/(.{1,#{col}})( +|$\n?)|(.{1,#{col}})/, "\\1\\3\n")
+  end
+end

--- a/app/workers/og_image_worker.rb
+++ b/app/workers/og_image_worker.rb
@@ -12,15 +12,19 @@ class OgImageWorker
     title.gravity = Magick::CenterGravity
     title.annotate(img, 0, 0, 0, 140, wrap_text(page_title))
 
-    dir = if Rails.env.test?
-            "#{Rails.root}/public/images/opengraph/test/#{project_id}/#{page_id}"
-          else
-            "#{Rails.root}/public/images/opengraph/#{project_id}/#{page_id}"
-          end
+    dir = og_image_path(project_id, page_id)
 
     FileUtils.mkdir_p(dir)
 
     img.write("#{dir}/og-image.jpg")
+  end
+
+  def og_image_path(project_id, page_id)
+    if Rails.env.test?
+      "#{Rails.root}/public/images/opengraph/test/#{project_id}/#{page_id}"
+    else
+      "#{Rails.root}/public/images/opengraph/#{project_id}/#{page_id}"
+    end
   end
 
   private

--- a/app/workers/og_image_worker.rb
+++ b/app/workers/og_image_worker.rb
@@ -3,35 +3,6 @@ class OgImageWorker
   sidekiq_options retry: false
 
   def perform(project_id, page_id, page_title)
-    img = Magick::ImageList.new("#{Rails.root}/public/images/qkspace.png")
-
-    title = Magick::Draw.new
-    title.font = "#{Rails.root}/public/assets/Lato-Regular.woff"
-    title.pointsize = 46
-    title.fill = 'white'
-    title.gravity = Magick::CenterGravity
-    title.annotate(img, 0, 0, 0, 140, wrap_text(page_title))
-
-    dir = og_image_path(project_id, page_id)
-
-    FileUtils.mkdir_p(dir)
-
-    img.write("#{dir}/og-image.jpg")
-  end
-
-  def og_image_path(project_id, page_id)
-    if Rails.env.test?
-      "#{Rails.root}/public/images/opengraph/test/#{project_id}/#{page_id}"
-    else
-      "#{Rails.root}/public/images/opengraph/#{project_id}/#{page_id}"
-    end
-  end
-
-  private
-
-  def wrap_text(text, col = 50)
-    # Regular expression to limit the number of chars per line
-    # default 50 chars each line
-    text.gsub(/(.{1,#{col}})( +|$\n?)|(.{1,#{col}})/, "\\1\\3\n")
+    OgImageService.new(project_id, page_id, page_title).generate
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module Dostoevsky
 
     config.middleware.use DomainSpaceMiddleware
     config.active_job.queue_adapter = :sidekiq
+    Redis.exists_returns_integer =  true
   end
 end

--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -10,10 +10,14 @@ namespace :og_images do
     puts  "Processing #{pages.size} pages"
 
     pages.find_each.with_index do |page, index|
-      image = "#{Rails.root}/public/images/opengraph/#{page.project_id}/#{page.id}/og-image.jpg"
+      worker = OgImageWorker.new
+
+      dir = worker.og_image_path(page.project_id, page.id)
+
+      image = "#{dir}/og-image.jpg"
 
       unless File.exist?(image)
-        OgImageWorker.new.perform(page.project_id, page.id, page.title)
+        worker.perform(page.project_id, page.id, page.title)
 
         generated_count += 1
       end

--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -1,5 +1,3 @@
-require "#{Rails.root}/app/workers/og_image_worker.rb"
-
 namespace :og_images do
   desc "Generating OpenGraph Images for existing pages"
   task generate: :environment do
@@ -10,14 +8,12 @@ namespace :og_images do
     puts  "Processing #{pages.size} pages"
 
     pages.find_each.with_index do |page, index|
-      worker = OgImageWorker.new
+      service = OgImageService.new(page.project_id, page.id, page.title)
 
-      dir = worker.og_image_path(page.project_id, page.id)
-
-      image = "#{dir}/og-image.jpg"
+      image = "#{service.og_image_path}/og-image.jpg"
 
       unless File.exist?(image)
-        worker.perform(page.project_id, page.id, page.title)
+        service.generate
 
         generated_count += 1
       end

--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -10,7 +10,6 @@ namespace :og_images do
     puts  "Processing #{pages.size} pages"
 
     pages.find_each.with_index do |page, index|
-
       image = "#{Rails.root}/public/images/opengraph/#{page.project_id}/#{page.id}/og-image.jpg"
 
       unless File.exist?(image)

--- a/lib/tasks/og_images.rake
+++ b/lib/tasks/og_images.rake
@@ -3,16 +3,27 @@ require "#{Rails.root}/app/workers/og_image_worker.rb"
 namespace :og_images do
   desc "Generating OpenGraph Images for existing pages"
   task generate: :environment do
+    generated_count = 0
+
     pages = Page.all
 
     puts  "Processing #{pages.size} pages"
 
     pages.find_each.with_index do |page, index|
-      OgImageWorker.new.perform(page.project_id, page.id, page.title)
+
+      image = "#{Rails.root}/public/images/opengraph/#{page.project_id}/#{page.id}/og-image.jpg"
+
+      unless File.exist?(image)
+        OgImageWorker.new.perform(page.project_id, page.id, page.title)
+
+        generated_count += 1
+      end
 
       puts "Processing #{index} of #{pages.size}" if (index % 25).zero?
     end
 
-    puts "Processing complete. Generated #{pages.size} images."
+    puts "Processing complete."
+    puts "Images count: 109"
+    puts "Images generated: #{generated_count}" if generated_count.positive?
   end
 end

--- a/spec/services/og_image_service_spec.rb
+++ b/spec/services/og_image_service_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
-require 'sidekiq/testing'
-Sidekiq::Testing.fake!
 
-RSpec.describe OgImageWorker, type: :worker do
-  describe 'worker creates images' do
+RSpec.describe OgImageService, type: :service do
+  describe 'service creates images' do
     let(:pages) { create_list(:page, 5) }
 
     context 'before generate OGImage' do
@@ -19,7 +17,7 @@ RSpec.describe OgImageWorker, type: :worker do
         pages.each do |page|
           image = "#{Rails.root}/public/images/opengraph/test/#{page.project_id}/#{page.id}/og-image.jpg"
 
-          OgImageWorker.new.perform(page.project_id, page.id, page.title)
+          OgImageService.new(page.project_id, page.id, page.title).generate
 
           expect(File.exist?(image)).to be true
 


### PR DESCRIPTION
@installero
Fixes #158 
### В случае если изображения генерируются.
```
Processing 109 pages
Processing 0 of 109
Processing 25 of 109
Processing 50 of 109
Processing 75 of 109
Processing 100 of 109
Processing complete.
Images count: 109
Images generated: 103 
```
### В случае если изображения НЕ генерируются.
```
Processing 109 pages
Processing 0 of 109
Processing 25 of 109
Processing 50 of 109
Processing 75 of 109
Processing 100 of 109
Processing complete.
Images count: 109
```

Возможно стоит заменить **Processing** на **Checking**, и всегда выводить последнюю строку даже если изображения не генерировались, например:
```
Processing 109 pages
Processing 0 of 109
Processing 25 of 109
Processing 50 of 109
Processing 75 of 109
Processing 100 of 109
Processing complete.
Images count: 109
Images generated: 0
```